### PR TITLE
Fix: Prevent audio element recreation on mute

### DIFF
--- a/frontend/src/hooks/useAudioPlayer.ts
+++ b/frontend/src/hooks/useAudioPlayer.ts
@@ -147,7 +147,7 @@ export function useAudioPlayer(options: UseAudioPlayerOptions = {}) {
       audio.src = "";
       audio.load();
     };
-  }, [opts, state.isMuted]);
+  }, [opts]);
 
   // Update volume and mute state
   useEffect(() => {


### PR DESCRIPTION
The `useEffect` hook that initializes the `HTMLAudioElement` was being re-triggered whenever the mute state changed. This caused the audio element to be destroyed and recreated, leading to a loss of the current track's source and breaking the play/pause functionality.

This commit removes `state.isMuted` from the dependency array of the `useEffect` hook, ensuring that the audio element is only created once. A separate `useEffect` already handles updating the `muted` property of the audio element when the mute state changes.