### PR TITLE
Fix: Mute button restarts track and track does not loop

### DIFF
--- a/frontend/src/components/SwipeStack.tsx
+++ b/frontend/src/components/SwipeStack.tsx
@@ -103,7 +103,6 @@ export function SwipeStack({
         preloadTrack(nextTrack);
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentIndex, isStackVisible, isPageVisible, tracks, currentTrack, isInstructionCard, playTrack, preloadTrack]);
 
   useEffect(() => {

--- a/frontend/src/hooks/useAudioPlayer.ts
+++ b/frontend/src/hooks/useAudioPlayer.ts
@@ -104,8 +104,13 @@ export function useAudioPlayer(options: UseAudioPlayerOptions = {}) {
     };
 
     const handleEnded = () => {
-      setState((prev) => ({ ...prev, isPlaying: false }));
-      onTrackEndRef.current?.();
+      if (audioRef.current) {
+        audioRef.current.currentTime = 0;
+        audioRef.current.play();
+      } else {
+        setState((prev) => ({ ...prev, isPlaying: false }));
+        onTrackEndRef.current?.();
+      }
     };
 
     const handleError = () => {
@@ -214,7 +219,7 @@ export function useAudioPlayer(options: UseAudioPlayerOptions = {}) {
         onPlaybackErrorRef.current?.(errorMessage);
       }
     },
-    [opts, state.isMuted]
+    [opts]
   );
 
   const pause = useCallback(() => {


### PR DESCRIPTION
The mute button was causing the track to restart because the `playTrack` function in `useAudioPlayer` had `state.isMuted` as a dependency. This caused the `useEffect` in `SwipeStack` to re-trigger the `playTrack` function whenever the mute state changed.

This commit removes `state.isMuted` from the dependency array of `playTrack`.

Additionally, the `handleEnded` function in `useAudioPlayer` has been modified to loop the track when it finishes playing.