### PR TITLE
Fix(mobile): Resolve expo-av plugin error and choppy audio playback

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -15,6 +15,7 @@
         "@react-navigation/stack": "^7.4.8",
         "expo": "~54.0.10",
         "expo-audio": "^1.0.13",
+        "expo-av": "^16.0.7",
         "expo-font": "^14.0.8",
         "expo-image": "^3.0.8",
         "expo-splash-screen": "^31.0.10",
@@ -4843,6 +4844,23 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-av": {
+      "version": "16.0.7",
+      "resolved": "https://registry.npmjs.org/expo-av/-/expo-av-16.0.7.tgz",
+      "integrity": "sha512-QReef6/RYuZ4GekTcZZw5zY26pcPOmHqK6LMgFlPhnsT0ga97HJrgMc63pvIiojDP+q4oIv24g+QPD8ljZu4XQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-web": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
       }
     },
     "node_modules/expo-font": {

--- a/mobile/src/screens/SwipeScreen.tsx
+++ b/mobile/src/screens/SwipeScreen.tsx
@@ -138,9 +138,6 @@ export default function SwipeScreen() {
   const onSwipeComplete = async (direction: "left" | "right") => {
     const currentTrack = tracks[currentIndex];
 
-    // Stop current audio before moving to next track
-    audioActions.stop();
-
     if (currentTrack && currentTrack.id !== "instruction") {
       const status: EvaluationStatus =
         direction === "right" ? "like" : "dislike";


### PR DESCRIPTION
This commit addresses two issues in the mobile application:

1.  **Resolves `expo-av` PluginError:** The application failed to start due to a `PluginError` for `expo-av`. This was caused by an incomplete or corrupt `node_modules` directory. The fix was to run `npm install` within the `mobile` directory to correctly install and link all dependencies as defined in `package.json`.

2.  **Fixes Choppy Audio Playback:** On the swipe screen, audio playback was choppy and would restart between swipes instead of transitioning smoothly. This was because the `onSwipeComplete` function was calling an aggressive `audioActions.stop()` method, which would completely unload the audio player instance.

    This explicit `stop()` call was redundant, as the `useAudioPlayer` hook's `play()` action (triggered by a `useEffect` hook watching the current track index) already handles loading the new track. By removing the unnecessary `stop()` call, the audio player is no longer destroyed and rebuilt on every swipe, resulting in smooth, continuous playback as intended.