### PR TITLE
fix(mobile): Correct audio handling on card change

### DIFF
--- a/mobile/src/screens/SwipeScreen.tsx
+++ b/mobile/src/screens/SwipeScreen.tsx
@@ -54,6 +54,12 @@ export default function SwipeScreen() {
       console.warn("Playback error:", error, track);
     },
   });
+  const audioStateRef = useRef(audioState);
+  const audioActionsRef = useRef(audioActions);
+  useEffect(() => {
+    audioStateRef.current = audioState;
+    audioActionsRef.current = audioActions;
+  });
 
   // Handle app state changes
   useEffect(() => {
@@ -334,27 +340,29 @@ export default function SwipeScreen() {
       currentTrack.preview_url;
 
     if (isPlayable) {
+      const { currentTrack: currentAudioTrack, isPlaying } =
+        audioStateRef.current;
       const isSameTrackPlaying =
-        audioState.currentTrack?.id === currentTrack.id && audioState.isPlaying;
+        currentAudioTrack?.id === currentTrack.id && isPlaying;
 
       if (!isSameTrackPlaying) {
         console.log(
-          `[SwipeScreen] Auto-play check: track=${currentTrack.id}, isPlaying=${audioState.isPlaying}, currentTrack=${audioState.currentTrack?.id}`
+          `[SwipeScreen] Auto-play check: track=${currentTrack.id}, isPlaying=${isPlaying}, currentTrack=${currentAudioTrack?.id}`
         );
-        audioActions.play(currentTrack);
+        audioActionsRef.current.play(currentTrack);
       }
     } else {
       // If not playable (e.g., instruction card), ensure audio is paused
-      if (audioState.isPlaying) {
+      if (audioStateRef.current.isPlaying) {
         console.log(
           `[SwipeScreen] Pausing audio for non-playable track: ${
             currentTrack?.id || "N/A"
           }`
         );
-        audioActions.pause();
+        audioActionsRef.current.pause();
       }
     }
-  }, [currentIndex, tracks, audioState, audioActions]);
+  }, [currentIndex, tracks]);
 
   // Handle play/pause
   const handlePlayToggle = () => {


### PR DESCRIPTION
Refactored the auto-play logic in `SwipeScreen.tsx` to prevent audio from playing incorrectly and to fix an infinite re-render loop.

The `useEffect` hook now uses `useRef` to safely access the latest audio state and actions, breaking a dependency cycle that caused the loop. The logic correctly pauses audio for non-playable cards (e.g., the instruction card) and plays it for playable ones.

This resolves an issue where sound would briefly play and then stop when a new card appeared, and it also fixes the subsequent "Maximum update depth exceeded" error.